### PR TITLE
Ignore commands regexp

### DIFF
--- a/maple-minibuffer.el
+++ b/maple-minibuffer.el
@@ -76,6 +76,11 @@
   :type 'list
   :group 'maple-minibuffer)
 
+(defcustom maple-minibuffer:ignore-regexp "^$"
+  "Mapple minibuffer ignore regular expression."
+  :type 'string
+  :group 'maple-minibuffer)
+
 (defcustom maple-minibuffer:cache t
   "Whether use frame cache."
   :type 'boolean
@@ -184,6 +189,7 @@
   (if (or (minibufferp)
           (not (display-graphic-p))
           (memq this-command maple-minibuffer:ignore-action)
+          (string-match maple-minibuffer:ignore-regexp (symbol-name this-command))
           (frame-parameter (selected-frame) 'maple-minibuffer))
       (apply oldfun args)
     (maple-minibuffer:with (apply oldfun args))))

--- a/maple-minibuffer.el
+++ b/maple-minibuffer.el
@@ -182,6 +182,7 @@
 (defun maple-minibuffer:read (oldfun &rest args)
   "Around minibuffer read OLDFUN with ARGS."
   (if (or (minibufferp)
+          (not (display-graphic-p))
           (memq this-command maple-minibuffer:ignore-action)
           (frame-parameter (selected-frame) 'maple-minibuffer))
       (apply oldfun args)


### PR DESCRIPTION
Hello,

thanks for this nice feature.

While using it, I realized that "Helm-*" is not properly compatible with the current framework.  To solve this, and be more general, I propose to filter commands based on a regular expression. 

I also added a small change to be able to activate the mode using the daemon mode as well. Basically, it simply ignores the maple part if no graphic is detected.

