### PR TITLE
Fix window center computation for frames with internal-border-width

### DIFF
--- a/maple-minibuffer.el
+++ b/maple-minibuffer.el
@@ -146,7 +146,9 @@
   (let* ((width (with-selected-frame frame (window-pixel-width)))
          (height (with-selected-frame frame (window-pixel-height)))
          (frame-center (/ (max 0 (- (frame-pixel-width) width)) 2))
-         (window-center (+ (window-pixel-left) (/ (max 0 (- (window-pixel-width) width)) 2))))
+         (window-center (+ (window-pixel-left)
+                           (/ (max 0 (- (window-pixel-width) width)) 2)
+                           (frame-parameter (selected-frame) 'internal-border-width))))
     (pcase maple-minibuffer:position-type
       ('frame-center
        (cons frame-center


### PR DESCRIPTION
Thanks for open-sourcing this package!

I noticed that the frame is slightly too far to the left in my setup. It turns out it's because the computation for the window center does not take internal border widths into account.

Without the fix
![current](https://user-images.githubusercontent.com/11087545/136427593-9c956777-5c57-4050-bf9f-374bb2df307c.png)

and with the fix
![fixed](https://user-images.githubusercontent.com/11087545/136427621-3c11099a-e87d-429a-b067-45a3a708cca5.png)

Edit: I should've used a dark theme, but you can see the effect when enlarging the images by clicking on them.